### PR TITLE
generate_samples.py - If path contains "train", all shards are classified as set_group train.

### DIFF
--- a/dataset/generate_samples.py
+++ b/dataset/generate_samples.py
@@ -109,7 +109,8 @@ if __name__ == "__main__":
     shard_idx = {"train": 0, "test": 0}
     for dup_idx in range(args.dup_factor):
         for f in shard_files:
-            set_group = "train" if "train" in f else "test"
+            file_name = os.path.basename(f)
+            set_group = "train" if "train" in file_name else "test"
             last_process = create_shard(f, shard_idx[set_group], set_group, args)
             shard_idx[set_group] += 1
     last_process.wait()


### PR DESCRIPTION
First of all, I want to thank you (1) for the great and really interesting paper and (2) for providing such a clean source code. I started to reproduce results from your paper and found the following bug which I want to share with you:

In `generate_samples.py` its evaluated whether the set_group is "train" or "test" via the check `if "train" in f` (line 112) where f could be the complete path to the shard file. Unfortunately, my path already contained ".../.../train/..." such that no single test file was generated. I would suggest changing line 112 to check only the basename.

Best, 
David