### PR TITLE
Fixed run_glue script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 deepspeed==0.4.3
 transformers==4.4.0
+datasets
 numpy
 tqdm
 sklearn

--- a/run_glue.py
+++ b/run_glue.py
@@ -24,7 +24,7 @@ import random
 import sys
 from argparse import Namespace
 from pretraining.args.deepspeed_args import remove_cuda_compatibility_for_kernel_compilation
-from pretraining.modeling import BertForSequenceClassification
+# from pretraining.modeling import BertForSequenceClassification
 from pretraining.configs import PretrainedBertConfig
 from dataclasses import dataclass, field
 from typing import Optional
@@ -32,7 +32,7 @@ import uuid
 
 import numpy as np
 import transformers
-from dataset import load_dataset, load_metric
+from run_pretraining import load_dataset, load_metric
 from transformers import (
     AutoConfig,
     AutoModelForSequenceClassification,

--- a/run_glue.py
+++ b/run_glue.py
@@ -24,7 +24,7 @@ import random
 import sys
 from argparse import Namespace
 from pretraining.args.deepspeed_args import remove_cuda_compatibility_for_kernel_compilation
-# from pretraining.modeling import BertForSequenceClassification
+from pretraining.modeling import BertForSequenceClassification
 from pretraining.configs import PretrainedBertConfig
 from dataclasses import dataclass, field
 from typing import Optional
@@ -32,7 +32,7 @@ import uuid
 
 import numpy as np
 import transformers
-from run_pretraining import load_dataset, load_metric
+from datasets import load_dataset, load_metric
 from transformers import (
     AutoConfig,
     AutoModelForSequenceClassification,


### PR DESCRIPTION
Fixes the run_glue script #10 . 
The problem was not that the functions were not imported from the local dataset directory 
as assumed in #9 

The problem was that the [datasets package] (https://huggingface.co/docs/datasets/installation.html)
was not listed in the `requirements.txt`

I was able to run the script using this setup. 